### PR TITLE
Second attempt at a good Mac OS X Mavericks/Homebrew build.

### DIFF
--- a/fluttercoin-qt.pro
+++ b/fluttercoin-qt.pro
@@ -16,6 +16,21 @@ CONFIG += thread
 #    BOOST_INCLUDE_PATH, BOOST_LIB_PATH, BDB_INCLUDE_PATH,
 #    BDB_LIB_PATH, OPENSSL_INCLUDE_PATH and OPENSSL_LIB_PATH respectively
 
+# Slax0r - Added for Max OS X Mavericks/Homebrew build
+macx: {
+BDB_LIB_SUFFIX = -5.3
+BOOST_INCLUDE_PATH=/usr/local/include
+BOOST_LIB_PATH=/usr/local/lib
+BDB_INCLUDE_PATH=/usr/local/include
+BDB_LIB_PATH=/usr/local/lib
+OPENSSL_INCLUDE_PATH=/usr/local/include
+OPENSSL_LIB_PATH=/usr/local/lib
+MINIUPNPC_INCLUDE_PATH=/usr/local/include
+MINIUPNPC_LIB_PATH=/usr/local/lib
+QRENCODE_INCLUDE_PATH=/usr/local/include
+QRENCODE_LIB_PATH=/usr/local/lib
+}
+
 OBJECTS_DIR = build
 MOC_DIR = build
 UI_DIR = build
@@ -23,7 +38,11 @@ UI_DIR = build
 # use: qmake "RELEASE=1"
 contains(RELEASE, 1) {
     # Mac: compile for maximum compatibility (10.5, 32-bit)
-    macx:QMAKE_CXXFLAGS += -mmacosx-version-min=10.5 -arch x86_64 -isysroot /Developer/SDKs/MacOSX10.5.sdk
+    #macx:QMAKE_CXXFLAGS += -mmacosx-version-min=10.5 -arch x86_64 -isysroot /Developer/SDKs/MacOSX10.5.sdk
+
+# Slaxor - Replaced the line above because version-min is 10.7 as this version of the SDK isnt even available anymore
+# and the removed arguments arent needed in modern build environments (ie the last 3 years)
+    macx:QMAKE_CXXFLAGS += -arch x86_64
 
     !windows:!macx {
         # Linux: static link
@@ -369,6 +388,7 @@ isEmpty(BOOST_THREAD_LIB_SUFFIX) {
 
 isEmpty(BDB_LIB_PATH) {
     macx:BDB_LIB_PATH = /opt/local/lib/db48
+    macx:BDB_LIB_PATH = /opt/local/lib/db48
 }
 
 isEmpty(BDB_LIB_SUFFIX) {
@@ -410,11 +430,14 @@ macx:HEADERS += src/qt/macdockiconhandler.h
 macx:OBJECTIVE_SOURCES += src/qt/macdockiconhandler.mm
 macx:LIBS += -framework Foundation -framework ApplicationServices -framework AppKit
 macx:DEFINES += MAC_OSX MSG_NOSIGNAL=0
-macx:ICON = src/qt/res/icons/bitcoin.icns
+# Slax0r  - changed from "bitcoin" to "fluttercoin" to pick up the correct icon
+macx:ICON = src/qt/res/icons/fluttercoin.icns
 macx:TARGET = "FlutterCoin-Qt"
-macx:QMAKE_CFLAGS_THREAD += -pthread
-macx:QMAKE_LFLAGS_THREAD += -pthread
-macx:QMAKE_CXXFLAGS_THREAD += -pthread
+
+# Slax0r -- no longer necessary on Mavericks
+#macx:QMAKE_CFLAGS_THREAD += -pthread
+#macx:QMAKE_LFLAGS_THREAD += -pthread
+#macx:QMAKE_CXXFLAGS_THREAD += -pthread
 
 # Set libraries and includes at end, to use platform-defined defaults if not overridden
 INCLUDEPATH += $$BOOST_INCLUDE_PATH $$BDB_INCLUDE_PATH $$OPENSSL_INCLUDE_PATH $$QRENCODE_INCLUDE_PATH

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -57,7 +57,7 @@ static bool vfLimited[NET_MAX] = {};
 static CNode* pnodeLocalHost = NULL;
 CAddress addrSeenByPeer(CService("0.0.0.0", 0), nLocalServices);
 uint64 nLocalHostNonce = 0;
-array<int, THREAD_MAX> vnThreadsRunning;
+boost::array<int, THREAD_MAX> vnThreadsRunning;
 static std::vector<SOCKET> vhListenSocket;
 CAddrMan addrman;
 

--- a/src/serialize.h
+++ b/src/serialize.h
@@ -811,6 +811,20 @@ public:
     iterator insert(iterator it, const char& x=char()) { return vch.insert(it, x); }
     void insert(iterator it, size_type n, const char& x) { vch.insert(it, n, x); }
 
+#if defined(MAC_OSX)
+    void insert(iterator it, std::vector<char>::const_iterator first, std::vector<char>::const_iterator last)
+	{
+	    assert(last - first >= 0);
+	    if (it == vch.begin() + nReadPos && (unsigned int)(last - first) <= nReadPos)
+	    {
+	        // special case for inserting at the front when there's room
+	        nReadPos -= (last - first);
+	        memcpy(&vch[nReadPos], &first[0], last - first);
+	    }
+	    else
+	        vch.insert(it, first, last);
+    }
+#else
     void insert(iterator it, const_iterator first, const_iterator last)
     {
         assert(last - first >= 0);
@@ -836,6 +850,8 @@ public:
 	    else
 	        vch.insert(it, first, last);
     }
+
+#endif
 
 #if !defined(_MSC_VER) || _MSC_VER >= 1300
     void insert(iterator it, const char* first, const char* last)


### PR DESCRIPTION
Ive made basically the same patches as before but this time I made sure that the changes won't break the Win or Linux platform builds.  The majority are Mac/Homebrew specific with the exception of the minor change to net.cpp which is taken from a patch the the original NovaCoin and other derivative coin source trees.

The build process for Mac is based on the mac build for BitCoin-Scrypt Coin which is very well documented.  The reference is: http://theotherbitcoin.com/downloads/ following the Mac instructions at the bottom of the page.
Other platforms' build docs are provided as well for Gitian builds.

Unfortunately Gitan will never be used to build the Mac release as it just isn't capable of doing so. It is Win and Linux only.    
